### PR TITLE
Make client ID customizable using a command line flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ var (
 	argKey                  = flag.String("key", "", "client private key for authentication, if required by server.")
 	argCert                 = flag.String("cert", "", "client certificate for authentication, if required by server.")
 	argPauseBetweenMessages = flag.String("pause-between-messages", "0s", "Adds a pause between sending messages to simulate sensors sending messages infrequently")
-	argTopicBasePath		= flag.String("topic-base-path", "", "topic base path, if empty the default is internal/mqtt-stresser")
+	argTopicBasePath        = flag.String("topic-base-path", "", "topic base path, if empty the default is internal/mqtt-stresser")
 )
 
 type Result struct {
@@ -185,7 +185,7 @@ func main() {
 		if strings.HasPrefix(*argConstantPayload, "@") {
 			verboseLogger.Printf("Set constant payload from file %s\n", *argConstantPayload)
 			payloadGenerator = filePayloadGenerator(*argConstantPayload)
-		}else {
+		} else {
 			verboseLogger.Printf("Set constant payload to %s\n", *argConstantPayload)
 			payloadGenerator = constantPayloadGenerator(*argConstantPayload)
 		}

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ var (
 	stopWaitLoop = false
 	randomSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	subscriberClientIdTemplate = "mqtt-stresser-sub-%s-worker%d-%d"
-	publisherClientIdTemplate  = "mqtt-stresser-pub-%s-worker%d-%d"
+	subscriberClientIdTemplate = "a:app:mariquita_1:sub-%s-worker%d-%d"
+	publisherClientIdTemplate  = "a:app:mariquita_1:pub-%s-worker%d-%d"
 	topicNameTemplate          = "internal/mqtt-stresser/%s/worker%d-%d"
 
 	errorLogger   = log.New(os.Stderr, "ERROR: ", log.Lmicroseconds|log.Ltime|log.Lshortfile)

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ var (
 	stopWaitLoop = false
 	randomSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	subscriberClientIdTemplate = "a:app:mariquita_1:sub-%s-worker%d-%d"
-	publisherClientIdTemplate  = "a:app:mariquita_1:pub-%s-worker%d-%d"
+	subscriberClientIdTemplate = "mqtt-stresser-sub-%s-worker%d-%d"
+	publisherClientIdTemplate  = "mqtt-stresser-pub-%s-worker%d-%d"
 	topicNameTemplate          = "internal/mqtt-stresser/%s/worker%d-%d"
 
 	errorLogger   = log.New(os.Stderr, "ERROR: ", log.Lmicroseconds|log.Ltime|log.Lshortfile)
@@ -52,6 +52,7 @@ var (
 	argCert                 = flag.String("cert", "", "client certificate for authentication, if required by server.")
 	argPauseBetweenMessages = flag.String("pause-between-messages", "0s", "Adds a pause between sending messages to simulate sensors sending messages infrequently")
 	argTopicBasePath        = flag.String("topic-base-path", "", "topic base path, if empty the default is internal/mqtt-stresser")
+	argClientIdPrefix       = flag.String("client-id-prefix", "", "client ID prefix, if empty the default is mqtt-stresser")
 )
 
 type Result struct {

--- a/worker.go
+++ b/worker.go
@@ -112,6 +112,10 @@ func (w *Worker) Run(ctx context.Context) {
 	}
 
 	topicName := fmt.Sprintf(topicNameTemplate, hostname, w.WorkerId, t)
+	if len(*argClientIdPrefix) > 0 {
+		subscriberClientIdTemplate = strings.Replace(subscriberClientIdTemplate, "mqtt-stresser", *argClientIdPrefix, 1)
+		publisherClientIdTemplate = strings.Replace(publisherClientIdTemplate, "mqtt-stresser", *argClientIdPrefix, 1)
+	}
 	subscriberClientId := fmt.Sprintf(subscriberClientIdTemplate, hostname, w.WorkerId, t)
 	publisherClientId := fmt.Sprintf(publisherClientIdTemplate, hostname, w.WorkerId, t)
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Some broker setups put restrictions on the client IDs used by MQTT clients for security or standardization requirements. We need a mechanism to customize the client ID prefix, maintaining the default configuration currently used.

### Change description
<!-- What does your code do? -->

Add a new optional `--client-id-prefix` command line flag to customize the client ID used to establish MQTT connections. Defaults to the current prefix (`mqtt-stresser`).

<!-- 
### Additional Notes
Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.